### PR TITLE
Add Auger recombination term

### DIFF
--- a/Code/Common/nondimensionalise.m
+++ b/Code/Common/nondimensionalise.m
@@ -63,8 +63,14 @@ p0 = kH*dH; % typical hole density in perovskite (m-3)
 % Bulk recombination parameters
 ni2   = ni^2/(dE*dH);  % non-dim. n_i^2
 brate = beta*dE*dH/G0; % rate constant for bimolecular recombination
-Cn = Augn*dE^2*dH/G0; % Auger recombination coefficient
-Cp = Augp*dE*dH^2/G0; % Auger recombination coefficient
+if any(Augn) && any(Augp)
+    Cn = Augn*dE^2*dH/G0; % Auger recombination coefficient
+    Cp = Augp*dE*dH^2/G0; % Auger recombination coefficient
+else
+    [Cn, Cp] = deal(0); % no Auger recombination
+    warning(['The parameters for Auger recombination (Augn and Augp) have not' ...
+        ' been specified in the parameters file, so they have been set to zero.']);
+end
 if tp>0 && tn>0
     gamma   = dH/(tp*G0); % rate constant for SRH recombination
     tor     = tn*dH/(tp*dE); % ratio of SRH carrier lifetimes

--- a/Code/Plotting/README.md
+++ b/Code/Plotting/README.md
@@ -5,3 +5,4 @@ This folder contains scripts for plotting the solution, after the solution struc
 
 For example:
 - plot_sections.m can be used to plot a J-V curve
+- plot_recombination.m plots the rates of different types of bulk recombination

--- a/Code/Plotting/plot_recombination.m
+++ b/Code/Plotting/plot_recombination.m
@@ -1,0 +1,72 @@
+function plot_recombination(sol)
+% Plots the rates of different types of bulk recombination as functions of
+% time and space.
+
+% Retrieve the nondimensional parameter values and recombination functions
+[G0, dE, dH, N0, brate, ni2, gamma, tor, tor3, Cn, Cp, R, SRH, Auger, jay] = ...
+	struct2array(sol.params, {'G0','dE','dH','N0','brate','ni2','gamma', ...
+                              'tor','tor3','Cn','Cp','R','SRH','Auger','jay'});
+
+% Unpack the dimensional charge concentrations and time
+[n, p, P] = struct2array(sol.dstrbns, {'n','p','P'});
+
+% Unpack the time and spatial dimension across the perovskite layer
+time = sol.time;
+x = sol.vectors.x;
+
+% Compute the rates of recombination
+R_tot = G0*R(n/dE,p/dH,P/N0);
+R_bim = G0*brate*(n/dE.*p/dH-ni2);
+R_Aug = G0*Auger(n/dE,p/dH,Cn,Cp,ni2);
+R_SRH = G0*SRH(n/dE,p/dH,gamma,ni2,tor,tor3);
+
+% Set default figure options
+set(0,'defaultAxesFontSize',10); % Make axes labels smaller
+set(0,'defaultTextInterpreter','latex') % For latex axis labels
+set(0,'defaultAxesTickLabelInterpreter','latex') % For latex tick labels
+set(0,'defaultLegendInterpreter','latex') % For latex legends
+
+% Plot the rates of recombination in space and time
+figure;
+subplot(2,2,1);
+surf(x,time,R_tot,'LineStyle','none');
+xlabel('Distance (nm)'); ylabel('Time (s)');
+title('Total recombination rate');
+subplot(2,2,2);
+surf(x,time,R_bim,'LineStyle','none');
+xlabel('Distance (nm)'); ylabel('Time (s)');
+title('Bimolecular recombination rate');
+subplot(2,2,3);
+surf(x,time,R_Aug,'LineStyle','none');
+xlabel('Distance (nm)'); ylabel('Time (s)');
+title('Auger recombination rate');
+subplot(2,2,4);
+surf(x,time,R_SRH,'LineStyle','none');
+xlabel('Distance (nm)'); ylabel('Time (s)');
+title('SRH recombination rate');
+sgtitle('Recombination rates (m$^{-3}\,$s$^{-1}$)','Interpreter','latex');
+
+% Integrate to find the current lost to each type of recombination
+J_tot = -jay*trapz(x/x(end),R_tot'/G0);
+J_bim = -jay*trapz(x/x(end),R_bim'/G0);
+J_Aug = -jay*trapz(x/x(end),R_Aug'/G0);
+J_SRH = -jay*trapz(x/x(end),R_SRH'/G0);
+
+% Reset default figure options
+set(0,'defaultAxesFontSize',18); % Make axes labels larger
+
+% Plot the integrated rates of recombination over time
+figure;
+hold on;
+plot(time,J_tot,'DisplayName','Total');
+plot(time,J_bim,'DisplayName','Bimolecular');
+plot(time,J_Aug,'DisplayName','Auger');
+plot(time,J_SRH,'DisplayName','SRH');
+for i = 1:100:length(time) % section markers
+    plot(time([i,i]),ylim,'k--','HandleVisibility','off');
+end
+ylabel('Current density (mA$\cdot$cm$^{-2}$)');
+xlabel('Time (s)');
+legend('Location','Best','FontSize',12);
+
+end

--- a/parameters_template.m
+++ b/parameters_template.m
@@ -82,6 +82,8 @@ DH    = 1e-6;    % hole diffusion coefficient in HTL (m2s-1)
 tn    = 3e-9;    % electron pseudo-lifetime for SRH (s)
 tp    = 3e-7;    % hole pseudo-lifetime for SRH (s)
 beta  = 0;       % bimolecular recombination rate (m3s-1)
+Augn  = 0;       % electron-dominated Auger recombination rate (m6s-1)
+Augp  = 0;       % hole-dominated Auger recombination rate (m6s-1)
 
 % Interface recombination (max. velocity ~ 1e5)
 betaE = 0;       % ETL/perovskite bimolecular recombination rate (m3s-1)


### PR DESCRIPTION
Add a term for Auger recombination to the bulk recombination rate in the perovskite, along with an extra plotting script which can be used to check and compare the rates of the different types of bulk recombination. The Auger recombination rate is implemented as:

R_Auger(n,p)  =  Augn * n * (n * p-n_i^2) + Augp * p * (n * p-n_i^2)  =  (Augn * n+Augp * p) * (n * p-n_i^2)

where Augn and Augp are the Auger coefficients in m^6/s. This choice ensures that R=0 when n * p = n_i^2. The values of the new parameters Augn and Augp need to be specified in the parameters file, otherwise they are set to zero.
